### PR TITLE
Move over to Transient

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -7,7 +7,7 @@
 ;; Keywords: vc tools
 
 ;; Package: magit-stgit
-;; Package-Requires: ((emacs "24.4") (magit "2.12.0") (magit-popup "2.12.0") (transient "0.3.7"))
+;; Package-Requires: ((emacs "24.4") (magit "2.12.0") (transient "0.3.7"))
 
 ;; Magit-StGit is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
@@ -61,7 +61,6 @@
 (require 'dash)
 
 (require 'magit)
-(require 'magit-popup)
 (require 'transient)
 
 ;;; Options
@@ -70,10 +69,6 @@
 (defgroup magit-stgit nil
   "StGit support for Magit."
   :group 'magit-extensions)
-
-(defgroup magit-stgit-commands nil
-  "Options controlling behavior of certain commands."
-  :group 'magit-stgit)
 
 (defcustom magit-stgit-executable "stg"
   "The name of the StGit executable."

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -351,7 +351,10 @@ one from the minibuffer."
 
 ;;;###autoload
 (defun magit-stgit-rename (oldname newname)
-  "Rename StGit patch OLDNAME to NEWNAME."
+  "Invoke `stg rename OLDNAME NEWNAME'.
+
+If called interactively, read OLDNAME and NEWNAME from the
+minibuffer."
   (interactive
    (list (magit-stgit-read-patch "Patch to rename" t)
          (read-from-minibuffer "New name: ")))

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -256,7 +256,7 @@ one from the minibuffer, and move to the next line."
   :man-page "stg"
   ["Stack"
    [("i"   "Init"         magit-stgit-init)
-    ("f"   "Float"        magit-stgit-float-popup)
+    ("f"   "Float"        magit-stgit-float)
     ("s"   "Sink"         magit-stgit-sink-popup)
     ("a"   "Goto"         magit-stgit-goto-popup)]
    [("c"   "Commit"       magit-stgit-commit-popup)
@@ -331,20 +331,23 @@ the minibuffer."
                      (transient-args 'magit-stgit-edit)))
   (magit-run-stgit-async "edit" "--edit" args patch))
 
-(magit-define-popup magit-stgit-float-popup
-  "Popup console for StGit float."
-  'magit-stgit-commands
-  :switches '((?k "Keep the local changes" "--keep"))
-  :actions  '((?f  "Float"  magit-stgit-float))
-  :default-action #'magit-stgit-float)
+(transient-define-prefix magit-stgit-float ()
+  "Move a set of patches toward the top of the stack."
+  :man-page "stg-float"
+  ["Arguments"
+   ("-k" "Keep the local changes" "--keep")]
+  ["Actions"
+   ("f" "Float" magit-stgit--float)])
 
 ;;;###autoload
-(defun magit-stgit-float (patches &rest args)
-  "Float StGit PATCHES to the top.
-Use ARGS to pass additional arguments."
-  (interactive (list (magit-stgit-read-patches t t t t "Float patch")
-                     (magit-stgit-float-arguments)))
-  (magit-run-stgit-and-mark-remove patches "float" args "--" patches))
+(defun magit-stgit--float (patches &rest args)
+  "Invoke `stg float ARGS... PATCHES...'.
+
+If called interactively, float the patches around point or read
+one from the minibuffer."
+  (interactive (cons (magit-stgit-read-patches t t t t "Float patch")
+                     (transient-args 'magit-stgit-float)))
+  (magit-run-stgit-and-mark-remove patches "float" args patches))
 
 ;;;###autoload
 (defun magit-stgit-rename (oldname newname)
@@ -362,7 +365,7 @@ Use ARGS to pass additional arguments."
                   "--to="
                   (lambda (prompt &optional default) (magit-stgit-read-patch prompt t))))
   :actions  '((?s  "Sink"  magit-stgit-sink))
-  :default-action #'magit-stgit-float)
+  :default-action #'magit-stgit--float)
 
 ;;;###autoload
 (defun magit-stgit-sink (patches &rest args)
@@ -659,7 +662,7 @@ the To, Cc, and Bcc fields for all patches."
     ["Delete patch" magit-stgit-delete-popup
      :help "Delete an StGit patch"]
     "---"
-    ["Float patch" magit-stgit-float-popup
+    ["Float patch" magit-stgit-float
      :help "Float StGit patch to the top"]
     ["Sink patch" magit-stgit-sink-popup
      :help "Sink StGit patch deeper down the stack"]

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -264,7 +264,7 @@ one from the minibuffer, and move to the next line."
     ("r"   "Repair"       magit-stgit-repair)
     ("R"   "Rebase"       magit-stgit-rebase)]
    [("z"   "Undo"         magit-stgit-undo)
-    ("Z"   "Redo"         magit-stgit-redo-popup)]]
+    ("Z"   "Redo"         magit-stgit-redo)]]
   ["Patch"
    [("N"   "New"          magit-stgit-new)
     ("g"   "Refresh"      magit-stgit-refresh)
@@ -576,19 +576,21 @@ ask for confirmation before deleting."
   (interactive (transient-args 'magit-stgit-undo))
   (magit-run-stgit "undo" args))
 
-(magit-define-popup magit-stgit-redo-popup
-  "Popup console for StGit redo."
-  'magit-stgit-commands
-  :options  '((?n "Undo the last N commands" "--number=" read-number))
-  :switches '((?h "Discard changes in index/worktree" "--hard"))
-  :actions  '((?Z  "Redo"  magit-stgit-redo))
-  :default-action #'magit-stgit-redo)
+(transient-define-prefix magit-stgit-redo ()
+  "Undo a previous undo operation."
+  :man-page "stg-redo"
+  ["Arguments"
+   ("-n" "Undo the last N undos" "--number="
+    :reader (lambda (prompt _initial-input history)
+              (number-to-string (read-number prompt nil history))))
+   ("-h" "Discard changes in index/worktree" "--hard")]
+  ["Actions"
+   ("Z" "Redo" magit-stgit--redo)])
 
 ;;;###autoload
-(defun magit-stgit-redo (&rest args)
-  "Undo the last undo operation.
-Use ARGS to pass additional arguments."
-  (interactive (magit-stgit-redo-arguments))
+(defun magit-stgit--redo (&rest args)
+  "Invoke `stg redo ARGS...'."
+  (interactive (transient-args 'magit-stgit-redo))
   (magit-run-stgit "redo" args))
 
 ;;;; magit-stgit-mail
@@ -716,8 +718,8 @@ the To, Cc, and Bcc fields for all patches."
     "---"
     ["Undo stack operation" magit-stgit-undo
      :help "Undo a previous stack operation"]
-    ["Undo the last undo operation" magit-stgit-redo-popup
-     :help "Undo the last undo operation"]))
+    ["Redo stack operation" magit-stgit-redo
+     :help "Undo a previous undo operation"]))
 
 (easy-menu-add-item 'magit-mode-menu '("Extensions") magit-stgit-mode-menu)
 

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -258,7 +258,7 @@ one from the minibuffer, and move to the next line."
    [("i"   "Init"         magit-stgit-init)
     ("f"   "Float"        magit-stgit-float)
     ("s"   "Sink"         magit-stgit-sink)
-    ("a"   "Goto"         magit-stgit-goto-popup)]
+    ("a"   "Goto"         magit-stgit-goto)]
    [("c"   "Commit"       magit-stgit-commit)
     ("C"   "Uncommit"     magit-stgit-uncommit)
     ("r"   "Repair"       magit-stgit-repair)
@@ -537,21 +537,21 @@ ask for confirmation before deleting."
                         patches ", "))))
       (magit-run-stgit-and-mark-remove patches "delete" args patches))))
 
-(magit-define-popup magit-stgit-goto-popup
-  "Popup console for StGit goto."
-  'magit-stgit-commands
-  :switches '((?k "Keep the local changes"            "--keep")
-              (?m "Check for patches merged upstream" "--merged"))
-  :actions  '((?a  "Goto"  magit-stgit-goto))
-  :default-action #'magit-stgit-goto)
+(transient-define-prefix magit-stgit-goto ()
+  "Make an arbitrary patch current."
+  :man-page "stg-goto"
+  ["Arguments"
+   ("-k" "Keep the local changes" "--keep")
+   ("-m" "Check for patches merged upstream" "--merged")]
+  ["Actions"
+   ("a" "Goto" magit-stgit--goto)])
 
 ;;;###autoload
-(defun magit-stgit-goto (patch &rest args)
-  "Set PATCH as target of StGit push and pop operations.
-Use ARGS to pass additional arguments."
-  (interactive (list (magit-stgit-read-patches nil nil t t "Goto patch")
-                     (magit-stgit-goto-arguments)))
-  (magit-run-stgit "goto" patch args))
+(defun magit-stgit--goto (patch &rest args)
+  "Invoke `stg goto ARGS... PATCH'."
+  (interactive (cons (car (magit-stgit-read-patches nil nil t t "Goto patch"))
+                     (transient-args 'magit-stgit-goto)))
+  (magit-run-stgit "goto" args patch))
 
 ;;;###autoload
 (defun magit-stgit-show (patch)
@@ -727,7 +727,7 @@ the To, Cc, and Bcc fields for all patches."
 (defvar magit-stgit-patch-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map "k" #'magit-stgit--delete)
-    (define-key map "a"  'magit-stgit-goto)
+    (define-key map "a" #'magit-stgit--goto)
     (define-key map (kbd "RET") #'magit-stgit-show)
     (define-key map "#" #'magit-stgit-mark-toggle)
     map))

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -74,7 +74,6 @@
   "Options controlling behavior of certain commands."
   :group 'magit-stgit)
 
-
 (defcustom magit-stgit-executable "stg"
   "The name of the StGit executable."
   :group 'magit-stgit
@@ -183,6 +182,11 @@ Any list in ARGS is flattened."
           original)
     sorted))
 
+;;; Marking
+
+(defvar-local magit-stgit-marked-patches nil
+  "Internal list of marked patches.")
+
 (defun magit-stgit-read-patches (use-region use-marks use-point require-match prompt)
   "Return list of selected patches.
 If USE-REGION and there is an active region, return marked
@@ -200,13 +204,8 @@ PROMPT."
         region
         (and use-marks
              (magit-stgit-patches-sorted magit-stgit-marked-patches))
-        (list (or (and use-point (magit-section-when stgit-patch))
+        (list (or (and use-point (magit-section-value-if 'stgit-patch))
                   (and prompt (magit-stgit-read-patch prompt require-match)))))))
-
-;;; Marking
-
-(defvar-local magit-stgit-marked-patches nil
-  "Internal list of marked patches.")
 
 (defun magit-stgit-mark-contains (patch)
   "Whether the given PATCH is marked."

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -260,7 +260,7 @@ one from the minibuffer, and move to the next line."
     ("s"   "Sink"         magit-stgit-sink)
     ("a"   "Goto"         magit-stgit-goto-popup)]
    [("c"   "Commit"       magit-stgit-commit)
-    ("C"   "Uncommit"     magit-stgit-uncommit-popup)
+    ("C"   "Uncommit"     magit-stgit-uncommit)
     ("r"   "Repair"       magit-stgit-repair)
     ("R"   "Rebase"       magit-stgit-rebase-popup)]
    [("z"   "Undo"         magit-stgit-undo-popup)
@@ -422,17 +422,20 @@ one from the minibuffer."
                       (or patches (error "No patches provided")))))
     (magit-run-stgit-and-mark-remove patches "commit" args patches)))
 
-(magit-define-popup magit-stgit-uncommit-popup
-  "Popup console for StGit uncommit."
-  'magit-stgit-commands
-  :options  '((?n "Uncommit the specified number of commits" "--num=" read-number))
-  :actions  '((?C  "Uncommit"  magit-stgit-uncommit))
-  :default-action #'magit-stgit-uncommit)
+(transient-define-prefix magit-stgit-uncommit ()
+  "Uncommit a set of patches."
+  :man-page "stg-uncommit"
+  ["Arguments"
+   ("-n" "Uncommit the first N commits from the base down" "--number="
+    :reader (lambda (prompt _initial-input history)
+              (number-to-string (read-number prompt nil history))))]
+  ["Actions"
+   ("C" "Uncommit" magit-stgit--uncommit)])
 
 ;;;###autoload
-(defun magit-stgit-uncommit (&rest args)
-  "Turn regular commits into StGit patches."
-  (interactive (-flatten (list (magit-stgit-uncommit-arguments))))
+(defun magit-stgit--uncommit (&rest args)
+  "Invoke `stg uncommit ARGS...'."
+  (interactive (transient-args 'magit-stgit-uncommit))
   (magit-run-stgit "uncommit" args))
 
 (magit-define-popup magit-stgit-refresh-popup
@@ -681,7 +684,7 @@ the To, Cc, and Bcc fields for all patches."
      :help "Edit a patch"]
     ["Commit patch" magit-stgit-commit
      :help "Permanently store the base patch into the stack base"]
-    ["Uncommit patch" magit-stgit-uncommit-popup
+    ["Uncommit patch" magit-stgit-uncommit
      :help "Turn a regular commit into an StGit patch"]
     ["Delete patch" magit-stgit-delete-popup
      :help "Delete an StGit patch"]

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -269,7 +269,7 @@ one from the minibuffer, and move to the next line."
    [("N"   "New"          magit-stgit-new)
     ("g"   "Refresh"      magit-stgit-refresh-popup)
     ("RET" "Show"         magit-stgit-show)]
-   [("e"   "Edit"         magit-stgit-edit-popup)
+   [("e"   "Edit"         magit-stgit-edit)
     ("n"   "Rename"       magit-stgit-rename)
     ("k"   "Delete"       magit-stgit-delete-popup)]
    [("m"   "Mail patches" magit-stgit-mail-popup)]])
@@ -310,21 +310,26 @@ If called interactively, read NAME from the minibuffer."
                      (transient-args 'magit-stgit-new)))
   (magit-run-stgit-async "new" args name))
 
-(magit-define-popup magit-stgit-edit-popup
-  "Popup console for StGit edit."
-  'magit-stgit-commands
-  :switches '((?s "Add \"Signed-off-by:\" line" "--sign")
-              (?a "Add \"Acked-by:\" line" "--ack"))
-  :actions  '((?e  "Edit"  magit-stgit-edit))
-  :default-action #'magit-stgit-edit)
+(transient-define-prefix magit-stgit-edit ()
+  "Edit the description of an existing patch."
+  :man-page "stg-edit"
+  ["Arguments"
+   ("-s" "Add Signed-off-by" "--sign")
+   ("-a" "Add Acked-by" "--ack")]
+  ["Actions"
+   ("e" "Edit" magit-stgit--edit)])
 
 ;;;###autoload
-(defun magit-stgit-edit (patch &rest args)
-  "Edit the description of an existing StGit PATCH.
-Use ARGS to pass additional arguments."
-  (interactive (list (magit-stgit-read-patches nil nil t nil "Edit patch (default is top)")
-                     (magit-stgit-edit-arguments)))
-  (magit-run-stgit-async "edit" "--edit" args "--" patch))
+(defun magit-stgit--edit (&optional patch &rest args)
+  "Invoke `stg edit ARGS... PATCH'.
+
+If PATCH is nil, edit the current patch.
+
+If called interactively, edit the patch at point or read one from
+the minibuffer."
+  (interactive (cons (car (magit-stgit-read-patches nil nil t t "Edit patch"))
+                     (transient-args 'magit-stgit-edit)))
+  (magit-run-stgit-async "edit" "--edit" args patch))
 
 (magit-define-popup magit-stgit-float-popup
   "Popup console for StGit float."
@@ -645,7 +650,7 @@ the To, Cc, and Bcc fields for all patches."
      :help "Create a new StGit patch"]
     ["Rename patch" magit-stgit-rename
      :help "Rename a patch"]
-    ["Edit patch" magit-stgit-edit-popup
+    ["Edit patch" magit-stgit-edit
      :help "Edit a patch"]
     ["Commit patch" magit-stgit-commit-popup
      :help "Permanently store the base patch into the stack base"]


### PR DESCRIPTION
Here it is as promised. Suggestions welcome!

I've kept the conversion of each command as a separate commit so that it's easier to follow and review, but we can of course squash some of these later if this is too verbose.

The conversions all share a pattern -- convert the popup to a transient and slightly rework the corresponding command (update the docstring, make the code more idiomatic, fix any easy stuff, etc.).

As mentioned, I've tried not to break or significantly change any existing functionality, but I did take the opportunity to change a couple of small things here and there. In particular:

- We now require a minibuffer match when edit, refresh and sink (its target) prompt for a patch. Since `magit-stgit-read-patches` doesn't have a parameter for a default, I've removed the defaults from the prompts for now (not requiring a match and manually handling empty input, as the code was doing, is not the best way to handle the default I think).

- The commit command now also tries to read a patch from the minibuffer as a last resort (I'm not sure why the code was passing `t` for `REQUIRE-MATCH` but then `nil` for `PROMPT`, to `magit-stgit-read-patches`).

- The commit function now takes care to look out not just for `--all` but also `--number`. If these are specified, `PATCHES` is ignored (I don't know exactly why the code was expecting to find just a single patch in case of `--all`).

Questions:

- I don't know what names to use to differentiate between the transient and the function that does the work. Before we used to have the `-popup` suffix. For now I just decided to temporarily name them `magit-stgit-CMD` and `magit-stgit--CMD`. The double-dash name is definitely not good, as they're all public functions that the users can use (both interactively and programmatically). Ideas?

- Almost all of the commands rely on `magit-stgit-read-patches` to try and gather some patches. When it inspects both the region and the point, I've documented this as "patches **around** point"; when it inspects the point but not the region, I've used "patch **at** point" instead; and when it prompts for a patch, I've used "read one from the minibuffer". Is the around/at distinction good enough?

- My `magit-stgit--commit-need-patches-p` has to handle both `--number` and `--number=`, since we want `magit-stgit--commit` to be able to function regardless of the syntax the user/programmer decides to use for the options and whether or not it was invoked through Transient. There's no way around this, right?

- The key binding for the main `magit-stgit` popup was `/`, which I've left as is and added just after the Forge `@` key binding in `magit-dispatch`. Any better ideas?

Questions @tarsius:

- I used Transient 0.3.7. Is this too recent to use as a requirement?

- `magit-define-popup` used `magit-stgit-commands` as the Custom group. I wasn't able to find the equivalent of this in Transient so I removed it for now.

- I assume `transient-current-prefix` is the equivalent of `magit-current-popup`.

- I've used `:man-page` in all of the prefixes, but how do I do it for suffixes (e.g. `magit-stgit-init`)?

- Do infix arguments *have* to be strings, i.e. do I have to use `number-to-string` after `read-number`?

- Is there any benefit to *always* mentioning both the short and the long form for a Transient option (using a list of the form `(SHORT LONG)`)? Right now I don't do this anywhere.

Questions @jpgrayson:

- I assume StGit guarantees that it supports both `--long-option VAL` and `--long-option=VAL` option syntax, right?

- I've explicitly used `--` as a separator when invoking StGit commands to be able to handle any funny patch names. Could this be a problem, according to https://github.com/stacked-git/stgit/commit/7b87a0d91f50253bf26535b6fa645f21dde4e9e6?